### PR TITLE
Fix corporation planetary industry menu.

### DIFF
--- a/src/Http/routes.php
+++ b/src/Http/routes.php
@@ -82,10 +82,10 @@ Route::group([
 
 Route::group([
     'middleware' => ['web', 'auth', 'locale'],
-    'prefix' => '/corp-pi',
+    'prefix' => '/corporations/pi',
     'namespace' => 'HermesDj\Seat\SeatPlanetaryIndustry\Http\Controllers\Corporation'
 ], function () {
-    Route::get('/')
+    Route::get('/home')
         ->name('seat-pi::corporation-pi-home')
         ->uses('CorpPlanetaryIndustryController@home');
 


### PR DESCRIPTION
Apply the same fix as @recursivetree made but for corporations.

The menu stays open when the menu option for Corporation PI is selected.